### PR TITLE
Fix for first run by CRON

### DIFF
--- a/src/Model/Indexer/AbstractIndexer.php
+++ b/src/Model/Indexer/AbstractIndexer.php
@@ -88,6 +88,7 @@ abstract class AbstractIndexer implements ActionInterface, \Magento\Framework\Mv
             $stores = $store ? [$store] : $this->storeManager->getStores();
             foreach ($stores as $store) {
                 $this->appState->emulateAreaCode('frontend', function () use ($store, $ids) {
+                    $this->storeManager->setCurrentStore($store);
                     $this->reindex($store, $ids);
                     $this->afterReindex();
                 });


### PR DESCRIPTION
First cron run used storeId = 0, next runs was ok, but first was broken and throwed exception "catalog_category_product_index_store0' doesn't exist"